### PR TITLE
Add .claude/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.js
 .cursor/
+.claude/
 # testing
 /coverage
 


### PR DESCRIPTION
🚢 - @BelieveC
👍 - @BelieveC

## Description

Add .claude/ directory to .gitignore to exclude Claude-specific configuration from version control.

## Testing setup

No special setup required.

## Testing Scenarios:

- [x] Verify .claude/ directory is properly ignored
- [x] Ensure existing ignore patterns still work
- [x] Confirm gitignore file syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)